### PR TITLE
Trigger input event

### DIFF
--- a/datalist-polyfill.js
+++ b/datalist-polyfill.js
@@ -17,7 +17,18 @@
 
 	// in case of that the feature doesn't exist, emulate it's functionality
 	if ( !nativedatalist ) {
-		
+		//Customevent for IE
+		(function () {
+		  if ( typeof window.CustomEvent === "function" ) return false; //If not IE
+			  function CustomEvent ( event, params ) {
+		    params = params || { bubbles: false, cancelable: false, detail: undefined };
+		    var evt = document.createEvent( 'CustomEvent' );
+		    evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
+		    return evt;
+		   }
+		  CustomEvent.prototype = window.Event.prototype;
+		  window.CustomEvent = CustomEvent;
+		})();
 		// emulate the two properties regarding the datalist and input elements
 		// list property / https://developer.mozilla.org/en/docs/Web/API/HTMLInputElement
 		( function( constructor ) {
@@ -364,7 +375,7 @@
 						} else {
 							$inputList.value = selectValue;
 						}
-						
+						$inputList.dispatchEvent(new CustomEvent("input", {"bubbles":true, "cancelable": true}));
 						// set the visibility to false afterwards, as we're done here
 						visible = false;
 					}


### PR DESCRIPTION
In browsers such as Google Chrome it is possibly to listen when user pick up a datalist option using oninput event listener.
In polyfill oninput event was not triggered when the user picks an option. This fork will add oninput event to polyfill.