### PR TITLE
Fix case sensitive focusOut -> focusout event name

### DIFF
--- a/datalist-polyfill.js
+++ b/datalist-polyfill.js
@@ -326,12 +326,12 @@
           case 'focus':
             eventTarget.addEventListener('keyup', inputInputList);
 
-            eventTarget.addEventListener('focusOut', changesInputList, true);
+            eventTarget.addEventListener('focusout', changesInputList, true);
             break;
           case 'blur':
             eventTarget.removeEventListener('keyup', inputInputList);
 
-            eventTarget.removeEventListener('focusOut', changesInputList, true);
+            eventTarget.removeEventListener('focusout', changesInputList, true);
             break;
         }
       }


### PR DESCRIPTION
This changes the dropdown behavior so that focusing on an element other than the input and datalist causes the datalist polyfill to close. This seems to be the intended behavior and it is the behavior of non-polyfilled datalists.

Let me know if I should update the minified file in this PR as well.