### PR TITLE
Fix polyfill for input elements with class attribute

### DIFF
--- a/datalist-polyfill.js
+++ b/datalist-polyfill.js
@@ -284,7 +284,7 @@
 
 			// Test for whether this input has already been enhanced by the polyfill
 			if (
-				' ' + eventTarget.className + ' '.indexOf(' ' + classNameInput + ' ') <
+				(' ' + eventTarget.className + ' ').indexOf(' ' + classNameInput + ' ') <
 				0
 			) {
 				// We'd like to prevent autocomplete on the input datalist field


### PR DESCRIPTION
I noticed, that when an `input` element already has a class applied it would not get the `polyfilled` class. This is caused by the missing parentheses in this check.